### PR TITLE
feat(DieOptions): Add color to optional die parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   DieOptions.color is a new optional parameter (string) that can be passed to set the albedoColor of the mesh.
+
 ## [0.1.2] - 2021-06-09
 
 ### Fixed

--- a/src/diceThrower.ts
+++ b/src/diceThrower.ts
@@ -1,4 +1,15 @@
-import { AmmoJSPlugin, Engine, Mesh, PhysicsImpostor, Ray, Scene, SceneLoader, Vector3 } from "@babylonjs/core";
+import {
+    AmmoJSPlugin,
+    Color3,
+    Engine,
+    Mesh,
+    PBRMaterial,
+    PhysicsImpostor,
+    Ray,
+    Scene,
+    SceneLoader,
+    Vector3,
+} from "@babylonjs/core";
 import Ammo from "ammo.js";
 
 import { Dice, DieOptions } from "./types";
@@ -99,7 +110,7 @@ export class DiceThrower {
         root.addChild(collider);
 
         // custom colours
-        // (mesh.material as PBRMaterial).albedoColor = Color3.FromHexString("#ff0000");
+        if (options.color) (mesh.material as PBRMaterial).albedoColor = Color3.FromHexString(options.color);
 
         const defaultLinearVelocity = new Vector3(Math.random() * 10, 0, Math.random() * 10);
         const defaultAngularVelocity = new Vector3(Math.random() * 4, 0, Math.random() * 4);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,5 @@ export interface DieOptions {
     angular?: Vector3;
     size?: number;
     impostor?: PhysicsImpostorParameters;
+    color?: string;
 }


### PR DESCRIPTION
A hexstring can now be passed as an optional die parameter to set the albedo color of the mesh.

(This only works if the mesh has a PBRMaterial)