### PR TITLE
Streamline Parser API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   Parser.fromString now also accepts a single Options object if the same options apply to all dice
+
 ## [0.3.0] - 2021-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Parser.fromString now also accepts a single Options object if the same options apply to all dice
+-   `Parser.fromString` now also accepts a single Options object if the same options apply to all dice
+
+### Changed
+
+-   Removed option to pass `undefined` to `Parser` for diceThrower instance
 
 ## [0.3.0] - 2021-07-24
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -12,9 +12,7 @@ export abstract class Parser<T> {
     async fromString(input: string, options?: SimpleOptions | undefined | (SimpleOptions | undefined)[]): Promise<T> {
         const converted = this.inputToOptions(input);
         for (const [i, c] of converted.entries()) {
-            if (options !== undefined) {
-                converted[i] = { ...c, ...(Array.isArray(options) ? options[i] : options) };
-            }
+            converted[i] = { ...c, ...(Array.isArray(options) ? options[i] : options) };
         }
         return this.fromOptions(converted);
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1,17 +1,19 @@
 import { DiceThrower } from "../diceThrower";
 import { DieOptions } from "../types";
 
+type SimpleOptions = Omit<DieOptions, "die">;
+
 export abstract class Parser<T> {
     constructor(private diceThrower?: DiceThrower) {}
 
     protected abstract inputToOptions(input: string): DieOptions[];
     protected abstract resultsToOutput(results: number[]): T;
 
-    async fromString(input: string, options?: (Omit<DieOptions, "die"> | undefined)[]): Promise<T> {
+    async fromString(input: string, options?: SimpleOptions | undefined | (SimpleOptions | undefined)[]): Promise<T> {
         const converted = this.inputToOptions(input);
-        for (const [i, option] of (options ?? []).entries()) {
-            if (option) {
-                converted[i] = { ...converted[i], ...option };
+        for (const [i, c] of converted.entries()) {
+            if (options !== undefined) {
+                converted[i] = { ...c, ...(Array.isArray(options) ? options[i] : options) };
             }
         }
         return this.fromOptions(converted);

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -4,7 +4,7 @@ import { DieOptions } from "../types";
 type SimpleOptions = Omit<DieOptions, "die">;
 
 export abstract class Parser<T> {
-    constructor(private diceThrower?: DiceThrower) {}
+    constructor(private diceThrower: DiceThrower) {}
 
     protected abstract inputToOptions(input: string): DieOptions[];
     protected abstract resultsToOutput(results: number[]): T;
@@ -20,7 +20,7 @@ export abstract class Parser<T> {
     }
 
     async fromOptions(options: DieOptions[]): Promise<T> {
-        const results = (await this.diceThrower?.throwDice(options)) ?? [2, 3, 4, 5];
+        const results = await this.diceThrower.throwDice(options);
         return this.resultsToOutput(results);
     }
 }


### PR DESCRIPTION
This PR cleans up some of the Parser APIs.

- `Parser` no longer accepts `undefined` as a diceThrower in the constructor
- `Parser.fromString` now accepts a single Options set to be passed that will be used for all dice