### PR TITLE
Start dice in a random orientation

### DIFF
--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -219,6 +219,11 @@ export class DiceThrower {
         const vectors = options?.physics?.();
 
         mesh.position = vectors?.position ?? new Vector3(0, 10, 0);
+        mesh.rotation = new Vector3(
+            Math.random() * 2 * Math.PI,
+            Math.random() * 2 * Math.PI,
+            Math.random() * 2 * Math.PI
+        );
         const agg = new PhysicsAggregate(mesh, PhysicsShapeType.CONVEX_HULL, { mass: 20 });
         agg.body.setLinearVelocity(vectors?.linear ?? defaultLinearVelocity);
         agg.body.setAngularVelocity(vectors?.angular ?? defaultAngularVelocity);

--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -219,7 +219,7 @@ export class DiceThrower {
         const vectors = options?.physics?.();
 
         mesh.position = vectors?.position ?? new Vector3(0, 10, 0);
-        mesh.rotation = new Vector3(
+        mesh.rotation = vectors?.rotation ?? new Vector3(
             Math.random() * 2 * Math.PI,
             Math.random() * 2 * Math.PI,
             Math.random() * 2 * Math.PI

--- a/src/3d/options.ts
+++ b/src/3d/options.ts
@@ -7,5 +7,6 @@ export interface DieOptions {
         position?: Vector3;
         linear?: Vector3;
         angular?: Vector3;
+        rotation?: Vector3;
     };
 }


### PR DESCRIPTION
Currently, dice are always created in the same orientation. While that's not inherently an issue if the dice are given high angular velocity, if the dice are given a low angular velocity, they can become biased.

This gives the dice a random rotation by default, but can be set to a specific rotation via DieOptions.