### PR TITLE
Make dice clearable manually or after configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add ability to configure dice clear timeout
+    - Setting to a negative timeout disables automatic clearing
+
 ## [0.6.0] - 2024-08-10
 
 This is a release that changes a lot to the API!

--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -52,7 +52,7 @@ export class DiceThrower {
         canvas?: HTMLCanvasElement;
         tresholds?: { linear: number; angular: number };
         freezeOnDecision?: boolean;
-        clearAfter: number;
+        clearAfter?: number;
         antialias?: boolean;
         engineOptions?: EngineOptions;
     }) {

--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -155,15 +155,6 @@ export class DiceThrower {
         }
     }
 
-    clear(): void {
-        for (const [key, activeRolls] of this.activeRolls.entries()) {
-            this.activeRolls.delete(key);
-            for(const activeRoll of activeRolls) {
-                activeRoll.mesh.dispose();
-            }
-        }
-    }
-
     async rollString<Q>(inputString: string, rollOptions?: Q): Promise<RollResult<Part>> {
         if (!this.activeDiceSystem) {
             throw new Error("No dice system loaded. Call .loadSystem() first!");

--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -40,6 +40,7 @@ export class DiceThrower {
     };
 
     freezeOnDecision = true;
+    clearAfter = 5000;
 
     private activeDiceSystem: DiceSystem<Part, unknown> | undefined;
 
@@ -51,6 +52,7 @@ export class DiceThrower {
         canvas?: HTMLCanvasElement;
         tresholds?: { linear: number; angular: number };
         freezeOnDecision?: boolean;
+        clearAfter: number;
         antialias?: boolean;
         engineOptions?: EngineOptions;
     }) {
@@ -67,6 +69,9 @@ export class DiceThrower {
         }
         if (options.freezeOnDecision) {
             this.freezeOnDecision = options.freezeOnDecision;
+        }
+        if (options.clearAfter) {
+            this.clearAfter = options.clearAfter;
         }
     }
 
@@ -139,13 +144,22 @@ export class DiceThrower {
                     allDone = false;
                 }
             }
-            if (allDone) {
+            if (allDone && this.clearAfter > 0) {
                 this.activeRolls.delete(key);
                 setTimeout(() => {
                     for (const activeRoll of activeRolls) {
                         activeRoll.mesh.dispose();
                     }
-                }, 5000);
+                }, this.clearAfter);
+            }
+        }
+    }
+
+    clear(): void {
+        for (const [key, activeRolls] of this.activeRolls.entries()) {
+            this.activeRolls.delete(key);
+            for(const activeRoll of activeRolls) {
+                activeRoll.mesh.dispose();
             }
         }
     }


### PR DESCRIPTION
Currently the dice disappear after 5 seconds and there is no option to configure this. I think it would be nice to make this value configurable. I would also like to see there be a way to clear the dice manually so that you could choose to clear the old results right before a new roll starts rather than after a fixed timout period.