### PR TITLE
bug(System: DX): Improve d100 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+-   [3d] throwDice returns thrown dieName to handle mixed rolls
+-   [System:Dx] Handle d100 rolls properly + support for either 0-99 or 1-100 mode
+    -   d100 rolls with 3d dice will now automatically roll a d100 and a d10 and accumulate the results into 1 number, this brings it in line with the 2d behaviour
+
 ## [0.6.0] - 2024-08-10
 
 This is a release that changes a lot to the API!

--- a/src/3d/diceThrower.ts
+++ b/src/3d/diceThrower.ts
@@ -23,8 +23,9 @@ import "@babylonjs/core/Physics/physicsEngineComponent";
 import "@babylonjs/core/Physics/v1/physicsEngineComponent";
 
 interface ActiveRoll {
+    dieName: string;
     mesh: Mesh;
-    resolve: (faceId: number) => void;
+    resolve: (value: { faceId: number; dieName: string }) => void;
     reject: () => void;
     pickVector?: Vector3;
     done: boolean;
@@ -131,7 +132,7 @@ export class DiceThrower {
                     const ray = new Ray(activeRoll.mesh.position, activeRoll.pickVector ?? new Vector3(0, 1, 0), 100);
                     const pickResult = this.scene.pickWithRay(ray);
                     if (pickResult?.hit) {
-                        activeRoll.resolve(pickResult.faceId);
+                        activeRoll.resolve({ faceId: pickResult.faceId, dieName: activeRoll.dieName });
                     } else {
                         activeRoll.reject();
                     }
@@ -167,7 +168,7 @@ export class DiceThrower {
     async throwDice(
         rolls: { name: string; options?: Omit<DieOptions, "key"> }[],
         defaultOptions?: DieOptions,
-    ): Promise<{ faceIds: number[]; key: string }> {
+    ): Promise<{ results: { faceId: number; dieName: string }[]; key: string }> {
         if (!this.loaded) {
             throw new Error("Physics Engine has not been properly loaded. first call .load()!");
         }
@@ -176,13 +177,14 @@ export class DiceThrower {
         const keyRolls: ActiveRoll[] = [];
         this.activeRolls.set(key, keyRolls);
 
-        const promises: Promise<number>[] = [];
+        const promises: Promise<{ faceId: number; dieName: string }>[] = [];
 
         for (const roll of rolls) {
             const mesh = this.createDie(roll.name, roll.options ?? defaultOptions);
             promises.push(
                 new Promise((resolve, reject) =>
                     keyRolls.push({
+                        dieName: roll.name,
                         mesh,
                         resolve,
                         reject,
@@ -194,7 +196,7 @@ export class DiceThrower {
             await new Promise((r) => setTimeout(r, 50)); // wait 50ms to throw next die
         }
 
-        return { faceIds: await Promise.all(promises), key };
+        return { results: await Promise.all(promises), key };
     }
 
     private createDie(meshName: string, options?: Omit<DieOptions, "die">): Mesh {

--- a/src/systems/dx/3d.ts
+++ b/src/systems/dx/3d.ts
@@ -1,6 +1,6 @@
 import type { DiceThrower, DieOptions } from "../../3d";
 import { type DiceSystem, Status } from "../../core/types";
-import { type DieSegment, type DxSegment, DxSegmentType, RollOptions, type WithDxStatus } from "./types";
+import { type DieSegment, type DxSegment, DxSegmentType, type RollOptions, type WithDxStatus } from "./types";
 import { DX } from ".";
 
 async function roll(

--- a/src/systems/dx/3d.ts
+++ b/src/systems/dx/3d.ts
@@ -1,21 +1,42 @@
 import type { DiceThrower, DieOptions } from "../../3d";
 import { type DiceSystem, Status } from "../../core/types";
-import { type DieSegment, type DxSegment, DxSegmentType, type WithDxStatus } from "./types";
+import { type DieSegment, type DxSegment, DxSegmentType, RollOptions, type WithDxStatus } from "./types";
 import { DX } from ".";
 
 async function roll(
     part: WithDxStatus<DxSegment, Status.PendingRoll>,
-    rollOptions: RollOptions,
+    rollOptions: RollOptions3d,
 ): Promise<WithDxStatus<DieSegment, Status.PendingEvaluation>> {
     if (part.type !== DxSegmentType.Die) {
         throw new Error(`Received a part of an unexpected type (${part.type})`);
     }
 
-    const results = await rollOptions.thrower.throwDice(
-        Array.from({ length: part.amount }, () => ({ name: part.die })),
-        rollOptions.dieDefaults,
-    );
-    const output = results?.faceIds.map((r) => FACE_VALUE_MAPPING[part.die]?.[r]) ?? [];
+    const handleD100 = part.die === Dice.D100;
+
+    // Prepare the list of dice to roll
+    // Splice in an extra D10 for every D100 if we're handling D100
+    const diceRollArray = Array.from({ length: part.amount * (handleD100 ? 2 : 1) }, (_, index) => ({
+        name: handleD100 && index % 2 !== 0 ? Dice.D10 : part.die,
+    }));
+
+    const { results } = await rollOptions.thrower.throwDice(diceRollArray, rollOptions.dieDefaults);
+
+    let output = results.map((r) => FACE_VALUE_MAPPING[r.dieName as DieSegment["die"]]?.[r.faceId]) ?? [];
+
+    // Combine D100 results into a single number
+    if (handleD100) {
+        output = output
+            .filter((_, index) => index % 2 === 0)
+            .map((_, index) => {
+                let tens = output[index];
+                let units = output[index + 1];
+                if (tens === 100) tens = 0;
+                if (units === 10) units = 0;
+                if (tens === 0 && units === 0) return rollOptions.d100Mode === 0 ? 0 : 100;
+
+                return tens + units;
+            });
+    }
 
     return {
         ...part,
@@ -51,12 +72,12 @@ const FACE_VALUE_MAPPING: Record<DieSegment["die"], number[]> = {
     [Dice.D100]: [50, 90, 10, 70, 30, 40, 100, 80, 20, 60, 50, 90, 10, 70, 30, 40, 100, 80, 20, 60],
 };
 
-interface RollOptions {
+interface RollOptions3d extends RollOptions {
     thrower: DiceThrower;
     dieDefaults?: Partial<DieOptions>;
 }
 
-export const DX3: DiceSystem<DxSegment, RollOptions> = {
+export const DX3: DiceSystem<DxSegment, RollOptions3d> = {
     ...DX,
     roll,
 };

--- a/src/systems/dx/index.ts
+++ b/src/systems/dx/index.ts
@@ -5,6 +5,7 @@ import {
     DxSegmentType,
     type OperatorSegment,
     type ResolvedDieOutput,
+    RollOptions,
     type WithDxStatus,
 } from "./types";
 
@@ -35,6 +36,7 @@ function randomInterval(min: number, max: number): number {
 
 export async function roll(
     part: WithDxStatus<DxSegment, Status.PendingRoll>,
+    rollOptions: RollOptions,
 ): Promise<WithDxStatus<DieSegment, Status.PendingEvaluation>> {
     if (part.type !== DxSegmentType.Die) {
         throw new Error(`Received a part of an unexpected type (${part.type})`);
@@ -42,9 +44,11 @@ export async function roll(
     return Promise.resolve({
         ...part,
         status: Status.PendingEvaluation,
-        output: Array.from({ length: part.amount }, () =>
-            Math.round(randomInterval(1, Number.parseInt(part.die.slice(1), 10))),
-        ),
+        output: Array.from({ length: part.amount }, () => {
+            const result = Math.round(randomInterval(1, Number.parseInt(part.die.slice(1), 10)));
+            if (part.die === "d100" && result === 100 && rollOptions.d100Mode === 0) return 0;
+            return result;
+        }),
     });
 }
 
@@ -222,7 +226,7 @@ function parse(
     return data;
 }
 
-export const DX: DiceSystem<DxSegment> = {
+export const DX: DiceSystem<DxSegment, RollOptions> = {
     collect,
     evaluate,
     parse,

--- a/src/systems/dx/index.ts
+++ b/src/systems/dx/index.ts
@@ -5,7 +5,7 @@ import {
     DxSegmentType,
     type OperatorSegment,
     type ResolvedDieOutput,
-    RollOptions,
+    type RollOptions,
     type WithDxStatus,
 } from "./types";
 

--- a/src/systems/dx/types.ts
+++ b/src/systems/dx/types.ts
@@ -30,6 +30,10 @@ export interface DieSegment extends Part {
     selectorValue?: number;
 }
 
+export interface RollOptions {
+    d100Mode: 0 | 100;
+}
+
 type RolledDieOutput = number[];
 export type ResolvedDieOutput = { roll: number; status?: "kept" | "dropped" | "overridden" }[];
 


### PR DESCRIPTION
This PR improves handling of d100 rolls in the Dx system.

It also does a minor adjustment to the 3d diceThrower API to handle mixed dice rolls better.

the Dx system now expects a new roll option in both 2d and 3d settings to determine d100Mode it can be either 0 (0-99 mode) or 100 (1-100 mode).

Additionally when a d100 is rolled in 3D, visually both a d100 and a d10 will be thrown and the result will be accumulated into 1 number as if it was 1 roll.

This closes #11