### PR TITLE
bug(Dx): Fix d100 handling when multiple d100s are thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+-   [System:Dx,3d] D100 handling was not correct when multiple d100s were rolled at once
+
 ## [0.7.0] - 2025-01-11
 
 -   [3d] throwDice returns thrown dieName to handle mixed rolls

--- a/src/systems/dx/3d.ts
+++ b/src/systems/dx/3d.ts
@@ -28,8 +28,8 @@ async function roll(
         output = output
             .filter((_, index) => index % 2 === 0)
             .map((_, index) => {
-                let tens = output[index];
-                let units = output[index + 1];
+                let tens = output[2 * index];
+                let units = output[2 * index + 1];
                 if (tens === 100) tens = 0;
                 if (units === 10) units = 0;
                 if (tens === 0 && units === 0) return rollOptions.d100Mode === 0 ? 0 : 100;


### PR DESCRIPTION
Originally reported in the main repo: https://github.com/Kruptein/PlanarAlly/issues/1552

The custom d100 logic was not taking into account the fact that the index after the filter is different from the index before the filter.