### PR TITLE
release: 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+-   [System:Dx,3d] D100 handling was not correct when multiple d100s were rolled at once
+
 ## [0.7.0] - 2025-01-11
 
 -   [3d] throwDice returns thrown dieName to handle mixed rolls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.7.1] - 2025-03-12
+
 ### Fixed
 
 -   [System:Dx,3d] D100 handling was not correct when multiple d100s were rolled at once

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@planarally/dice",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@planarally/dice",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "dependencies": {
                 "@babylonjs/core": "^7.43.0",
                 "@babylonjs/havok": "^1.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@planarally/dice",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "3D dice rolling functionality for babylon.js.",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/systems/dx/3d.ts
+++ b/src/systems/dx/3d.ts
@@ -28,8 +28,8 @@ async function roll(
         output = output
             .filter((_, index) => index % 2 === 0)
             .map((_, index) => {
-                let tens = output[index];
-                let units = output[index + 1];
+                let tens = output[2 * index];
+                let units = output[2 * index + 1];
                 if (tens === 100) tens = 0;
                 if (units === 10) units = 0;
                 if (tens === 0 && units === 0) return rollOptions.d100Mode === 0 ? 0 : 100;


### PR DESCRIPTION
This is a bugfix to the d100 implementation introduced in 0.7.0

When multiple d100s were thrown at the same time, a bug in the logic was adding up the wrong values. Which for 2 d100 seemed as if only 1 d10 was being used for both d100s