### PR TITLE
bug(3D, System:DX): Wrong D4 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+-   [System:Dx,3d] D4 was not using the correct pick vector, causing arbitrary results
+
 ## [0.7.1] - 2025-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+-   [3d] The raycast to check the hit is now stricter and explicitly only interacts with the mesh it's supposed to check
+
 ### Fixed
 
 -   [System:Dx,3d] D4 was not using the correct pick vector, causing arbitrary results

--- a/src/3d/dice-thrower.ts
+++ b/src/3d/dice-thrower.ts
@@ -180,7 +180,7 @@ export class DiceThrower {
     }
 
     async throwDice(
-        rolls: { name: string; options?: Omit<DieOptions, "key"> }[],
+        rolls: { name: string; options?: Omit<DieOptions, "key">; pickVector?: Vector3 }[],
         defaultOptions?: DieOptions,
     ): Promise<{ results: { faceId: number; dieName: string }[]; key: string }> {
         if (!this.loaded) {
@@ -203,6 +203,7 @@ export class DiceThrower {
                         mesh,
                         reject,
                         resolve,
+                        pickVector: roll.pickVector,
                     }),
                 ),
             );

--- a/src/3d/dice-thrower.ts
+++ b/src/3d/dice-thrower.ts
@@ -144,7 +144,7 @@ export class DiceThrower {
                     activeRoll.done = true;
 
                     const ray = new Ray(activeRoll.mesh.position, activeRoll.pickVector ?? new Vector3(0, 1, 0), 100);
-                    const pickResult = this.scene.pickWithRay(ray);
+                    const pickResult = this.scene.pickWithRay(ray, (mesh) => mesh === activeRoll.mesh);
                     if (pickResult?.hit) {
                         activeRoll.resolve({ dieName: activeRoll.dieName, faceId: pickResult.faceId });
                     } else {

--- a/src/systems/dx/3d.ts
+++ b/src/systems/dx/3d.ts
@@ -1,5 +1,8 @@
+import { Vector3 } from "@babylonjs/core";
+
 import type { DiceThrower, DieOptions } from "../../3d";
 import { type DiceSystem, Status } from "../../core/types";
+
 import { type DieSegment, type DxSegment, DxSegmentType, type RollOptions, type WithDxStatus } from "./types";
 import { DX } from ".";
 
@@ -17,6 +20,7 @@ async function roll(
     // Splice in an extra D10 for every D100 if we're handling D100
     const diceRollArray = Array.from({ length: part.amount * (handleD100 ? 2 : 1) }, (_, index) => ({
         name: handleD100 && index % 2 !== 0 ? Dice.D10 : part.die,
+        pickVector: part.die === Dice.D4 ? new Vector3(0, -1, 0) : undefined,
     }));
 
     const { results } = await rollOptions.thrower.throwDice(diceRollArray, rollOptions.dieDefaults);


### PR DESCRIPTION
The D4 is a shape that needs to be checked based on the face that is lying on the ground instead of the face that is pointing to the air.

This used to work in the old codebase, and the rework offers support for changing the pick vector in its API, but the Dx D4 was not actually setting this vector.

This fixes #14 

The raycast is now also stricter, which was needed for the D4 handling as it would sometimes pick up an intersection with the ground mesh instead of the D4 mesh. It now strictly only checks the mesh it's aiming at.